### PR TITLE
Nagios check should return the snap version regardless of its prefix

### DIFF
--- a/src/files/nagios/check_vault_version.py
+++ b/src/files/nagios/check_vault_version.py
@@ -37,7 +37,7 @@ def get_vault_snap_version():
         version = info['result']['version']
         if version.startswith('v'):
             version = version[1:]
-            return version
+        return version
 
 
 def get_vault_server_version(verify=True):


### PR DESCRIPTION
Currently the nagios check script will only return a version if it's prefixed with "v", which it'll strip before returning. This change will return it for comparison whether or not the prefix is present.