### PR TITLE
tox.ini: use abs path for true cmd in func-noop

### DIFF
--- a/src/tox.ini
+++ b/src/tox.ini
@@ -23,7 +23,7 @@ commands = charm-proof
 [testenv:func-noop]
 basepython = python3
 commands =
-    true
+    /bin/true
 
 [testenv:func]
 basepython = python3


### PR DESCRIPTION
Currently `tox -e func-noop` will print warning:

WARNING: test command found but not installed in testenv
  cmd: /bin/true
  env: /home/ubuntu/charm-builds/vault/.tox/func-noop
Maybe you forgot to specify a dependency? See also the whitelist_externals envconfig setting.

DEPRECATION WARNING: this will be an error in tox 4 and above!

Use abs path for `true` cmd will fix it.